### PR TITLE
Wrap Safari hack in User Agent test - Fixes #20

### DIFF
--- a/src/bigscreen.js
+++ b/src/bigscreen.js
@@ -253,11 +253,13 @@
 				// If there's no element after 100ms, it didn't work. This check is for Safari 5.1
 				// which fails to fire a `webkitfullscreenerror` if the request wasn't from a user
 				// action.
-				setTimeout(function() {
-					if (!document[fn.element]) {
-						callOnError(iframe ? 'not_enabled' : 'not_allowed', element);
-					}
-				}, 100);
+				if(navigator.userAgent.indexOf('Safari') > -1) {
+					setTimeout(function() {
+						if (!document[fn.element]) {
+							callOnError(iframe ? 'not_enabled' : 'not_allowed', element);
+						}
+					}, 100);
+				}
 			}
 			catch (err) {
 				callOnError('not_enabled', element);


### PR DESCRIPTION
- Firefox events were not being called correctly because the hack for Safari was triggering an error, which removed the element from the BigScreen instance
