### PR TITLE
Fix firefox not allowing full screen

### DIFF
--- a/src/bigscreen.js
+++ b/src/bigscreen.js
@@ -181,7 +181,7 @@
 	// an error occurs.
 	var callOnError = function(reason, element) {
 		if (elements.length > 0) {
-			var obj = elements.pop();
+			var obj = elements[0];
 			element = element || obj.element;
 
 			obj.error.call(element, reason);


### PR DESCRIPTION
Hi, 
I have the problem when firefox says "Request for full-screen was denied because Element.requestFullScreen() was not called from inside a short running"
I tried without taking out the element and it works. 
Let me know if there is any other way to fix it.